### PR TITLE
[Fixed] Focussable nav elements without outlines

### DIFF
--- a/assets/styles/atoms/nav-item/_nav-item.scss
+++ b/assets/styles/atoms/nav-item/_nav-item.scss
@@ -21,10 +21,6 @@
       color: palette("black");
     }
   }
-
-  &:focus {
-    outline: none;
-  }
 }
 
 .nav-item--block {


### PR DESCRIPTION
This PR removes the styles responsible for removing the browser default outline styles for focussable elements.

Relates to https://github.com/madebykind/shu-design-system-base/issues/9